### PR TITLE
Add app_permissions to ModalInteraction, fix typing

### DIFF
--- a/hikari/api/special_endpoints.py
+++ b/hikari/api/special_endpoints.py
@@ -897,11 +897,6 @@ class InteractionModalBuilder(InteractionResponseBuilder, abc.ABC):
         ----------
         title : builtins.str
             The title that will show up in the modal.
-
-        Returns
-        -------
-        InteractionModalBuilder
-            Object of this builder.
         """
 
     @abc.abstractmethod
@@ -912,11 +907,6 @@ class InteractionModalBuilder(InteractionResponseBuilder, abc.ABC):
         ----------
         custom_id : builtins.str
             The developer set custom ID used for identifying interactions with this modal.
-
-        Returns
-        -------
-        InteractionModalBuilder
-            Object of this builder.
         """
 
     @abc.abstractmethod
@@ -927,11 +917,6 @@ class InteractionModalBuilder(InteractionResponseBuilder, abc.ABC):
         ----------
         component : ComponentBuilder
             The component builder to add to this modal.
-
-        Returns
-        -------
-        InteractionModalBuilder
-            Object of this builder.
         """
 
 

--- a/hikari/impl/entity_factory.py
+++ b/hikari/impl/entity_factory.py
@@ -2140,6 +2140,8 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             member = None
             user = self.deserialize_user(payload["user"])
 
+        app_perms = payload.get("app_permissions")
+
         components: typing.List[typing.Any] = []
         for component_payload in data_payload["components"]:
             try:
@@ -2157,6 +2159,7 @@ class EntityFactoryImpl(entity_factory.EntityFactory):
             id=snowflakes.Snowflake(payload["id"]),
             type=base_interactions.InteractionType(payload["type"]),
             guild_id=guild_id,
+            app_permissions=permission_models.Permissions(app_perms) if app_perms is not None else None,
             guild_locale=locales.Locale(payload["guild_locale"]) if "guild_locale" in payload else None,
             locale=locales.Locale(payload["locale"]),
             channel_id=snowflakes.Snowflake(payload["channel_id"]),

--- a/hikari/impl/special_endpoints.py
+++ b/hikari/impl/special_endpoints.py
@@ -1128,7 +1128,7 @@ class InteractionModalBuilder(special_endpoints.InteractionModalBuilder):
 
     def build(
         self, entity_factory: entity_factory_.EntityFactory, /
-    ) -> typing.Tuple[data_binding.JSONObject, typing.Sequence[files.Resource[files.AsyncReader]]]:
+    ) -> typing.Tuple[typing.MutableMapping[str, typing.Any], typing.Sequence[files.Resource[files.AsyncReader]]]:
         data = data_binding.JSONObjectBuilder()
         data.put("title", self._title)
         data.put("custom_id", self._custom_id)
@@ -1639,7 +1639,7 @@ class TextInputBuilder(special_endpoints.TextInputBuilder[_ContainerProtoT]):
         self._container.add_component(self)
         return self._container
 
-    def build(self) -> data_binding.JSONObject:
+    def build(self) -> typing.MutableMapping[str, typing.Any]:
         data = data_binding.JSONObjectBuilder()
 
         data["type"] = messages.ComponentType.TEXT_INPUT

--- a/hikari/interactions/modal_interactions.py
+++ b/hikari/interactions/modal_interactions.py
@@ -38,6 +38,7 @@ import attr
 from hikari import channels
 from hikari import guilds
 from hikari import messages
+from hikari import permissions
 from hikari import snowflakes
 from hikari import traits
 from hikari.interactions import base_interactions
@@ -118,6 +119,9 @@ class ModalInteraction(base_interactions.MessageResponseMixin[ModalResponseTypes
 
     locale: str = attr.field(eq=False, hash=False, repr=True)
     """The selected language of the user who triggered this modal interaction."""
+
+    app_permissions: typing.Optional[permissions.Permissions] = attr.field(eq=False, hash=False, repr=False)
+    """Permissions the bot has in this interaction's channel if it's in a guild."""
 
     components: typing.Sequence[messages.ActionRowComponent] = attr.field(eq=False, hash=False, repr=True)
     """Components in the modal."""

--- a/tests/hikari/interactions/test_modal_interactions.py
+++ b/tests/hikari/interactions/test_modal_interactions.py
@@ -54,6 +54,7 @@ class TestModalInteraction:
             message=object(),
             locale="es-ES",
             guild_locale="en-US",
+            app_permissions=543123,
             components=special_endpoints.ActionRowBuilder(
                 components=[
                     modal_interactions.InteractionTextInput(


### PR DESCRIPTION
### Summary
Add `app_permissions` to ModalInteraction, fix some mypy errors.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
